### PR TITLE
add swagger api documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/
 __pycache__/
 *.pyc
+.pytest_cache/

--- a/app.py
+++ b/app.py
@@ -1,23 +1,24 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
+from flasgger import Swagger, swag_from
 from middleware.request_logger import setup_request_logger
 from validators import validate_feedback
+from swagger_docs.swagger_config import template
 
 # Initialize Flask app
 app = Flask(__name__)
 
 CORS(app)
 
+Swagger(app, template=template)
+
 setup_request_logger(app)
 
-# In-memery storage for feedback
+# In-memory storage for feedback
 feedback_store = []
 
-def is_valid_email(email: str) -> bool:
-    return re.match(r"[^@]+@[^@]+\.[^@]+", email) is not None
-
-
 @app.route("/api/feedback", methods=["POST"])
+@swag_from("swagger_docs/feedback_swagger.yml")
 def submit_feedback():
     data = request.get_json() or {}
 
@@ -26,17 +27,17 @@ def submit_feedback():
     if error:
         return error, 400
 
-    feedback_store.append(data)
+    feedback_store.append(validated_data)
 
     return jsonify({
         "message": "Feedback received successfully",
-        "data": data
+        "data": validated_data
     }), 201
 
 
 @app.route("/")
+@swag_from("swagger_docs/health_check_swagger.yml")
 def home():
-    """Health check endpoint to verify server is running."""
     return jsonify({"message": "Feedback API is live!"}), 200
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
 Werkzeug==3.1.3
+flasgger==0.9.7.1
+PyYAML==6.0.1

--- a/swagger_docs/feedback_swagger.yml
+++ b/swagger_docs/feedback_swagger.yml
@@ -1,0 +1,33 @@
+summary: Submit a new feedback
+description: This endpoint allows users to submit their feedback.
+parameters:
+  - name: body
+    in: body
+    required: true
+    schema:
+      $ref: '#/definitions/Feedback'
+responses:
+  201:
+    description: Feedback received successfully
+    schema:
+      type: object
+      properties:
+        message:
+          type: string
+        data:
+          $ref: '#/definitions/Feedback'
+    examples:
+      application/json:
+        message: "Feedback received successfully"
+        data:
+          rating: 5
+          opinion: "Great API!"
+          research: true
+          email: "test@example.com"
+  400:
+    description: Invalid input
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        message: "Rating is required"

--- a/swagger_docs/health_check_swagger.yml
+++ b/swagger_docs/health_check_swagger.yml
@@ -1,0 +1,8 @@
+summary: Health check
+description: This endpoint can be used to check if the API is live.
+responses:
+  200:
+    description: API is live
+    examples:
+      application/json:
+        message: "Feedback API is live!"

--- a/swagger_docs/swagger_config.py
+++ b/swagger_docs/swagger_config.py
@@ -1,0 +1,40 @@
+
+template = {
+    "swagger": "2.0",
+    "info": {
+        "title": "Feedback API",
+        "description": "A RESTful API for collecting user feedback.",
+        "version": "1.0.0"
+    },
+    "definitions": {
+        "Feedback": {
+            "type": "object",
+            "properties": {
+                "rating": {
+                    "type": "integer",
+                    "description": "Rating from 1 to 5"
+                },
+                "opinion": {
+                    "type": "string",
+                    "description": "User's opinion"
+                },
+                "research": {
+                    "type": "boolean",
+                    "description": "Opt-in for research"
+                },
+                "email": {
+                    "type": "string",
+                    "description": "User's email (required if research is true)"
+                }
+            }
+        },
+        "Error": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Feature: 

- Added `swagger_docs/` directory containing YAML specs for each endpoint
- Updated `app.py` to use `@swag_from` decorators, keeping the file clean and modular.
- Documentation now auto-generates a UI at `/apidocs/` for easier testing and exploration.